### PR TITLE
Define general error

### DIFF
--- a/src/Error.hs
+++ b/src/Error.hs
@@ -1,0 +1,15 @@
+module Error (
+  Error(..),
+  ErrorType(..),
+) where
+
+import Point
+
+data Error = Error ErrorType Message Point Source deriving (Eq, Show)
+
+data ErrorType = LexicographicalError | GrammaticalError | SemanticError deriving (Eq, Show)
+
+type Message = String
+
+type Source = String
+

--- a/src/Error.hs
+++ b/src/Error.hs
@@ -12,4 +12,3 @@ data ErrorType = LexicographicalError | GrammaticalError | SemanticError derivin
 type Message = String
 
 type Source = String
-

--- a/src/Lexer.hs
+++ b/src/Lexer.hs
@@ -45,8 +45,15 @@ consumeWord c ""                                 = Right ("", c)
 consumeWord c ('=':'>':xs)                       = Right ("=>", incrementColumn 2 c)
 consumeWord c w@(x:xs) | isPuntuation (x:"")     = Right (x:"", incrementColumn 1 c)
                        | otherwise               =  let word = nextWord w
-                                                    in Right (word, incrementColumn (toInteger (length word)) c)
+                                                    in checkWordlexicographically c w (word, incrementColumn (toInteger (length word)) c)
 
+checkWordlexicographically :: TContext -> String -> (String, TContext) -> Either Error (String, TContext)
+checkWordlexicographically c s tuple@(word, _)  | validWord word = Right tuple
+                                                | otherwise      = Left (Error LexicographicalError (word ++ " is not a valid word") (pointFromContext c) s) 
+
+validWord :: String -> Bool
+validWord "__" = False
+validWord _    = True
 ------------------------------
 
 tokenizeProgram :: String -> String -> Either Error [Token]

--- a/src/Point.hs
+++ b/src/Point.hs
@@ -1,0 +1,21 @@
+module Point (
+  Point(..),
+  emptyPoint,
+  updateRow,
+  updateIndex,
+  updateColumn,
+) where
+
+data Point = Point { row :: Integer, column :: Integer, index :: Integer } deriving (Eq, Show) -- index is the number of the current character respect the complete file
+
+emptyPoint :: Point
+emptyPoint = Point 0 0 0
+
+updateRow :: Point -> Point
+updateRow Point { row = r, column = c, index = i } = Point (r + 1) 0 i
+
+updateIndex :: Integer -> Point -> Point
+updateIndex n Point { row = r, column = c, index = i } = Point r c (i + n)
+
+updateColumn :: Integer -> Point -> Point
+updateColumn n Point { row = r, column = c, index = i } = Point r (c + n) i

--- a/src/TContext.hs
+++ b/src/TContext.hs
@@ -1,0 +1,31 @@
+module TContext (
+  TContext(..),
+  context,
+  applyIndexContext,
+  incrementRow,
+  incrementColumn,
+  incrementIndex,
+  pointFromContext,
+) where
+
+import Point
+
+data TContext = TContext { fileName :: String , source :: String , tIndex :: Point } deriving (Eq, Show)
+
+context :: String -> String -> TContext
+context name source = TContext name source emptyPoint
+
+applyIndexContext :: (Point -> Point) -> TContext -> TContext
+applyIndexContext f (TContext {fileName = name, source = s, tIndex = point}) = TContext name s (f point)
+
+incrementRow :: TContext -> TContext
+incrementRow = applyIndexContext updateRow
+
+incrementColumn :: Integer -> TContext -> TContext
+incrementColumn n = applyIndexContext (updateColumn n)
+
+incrementIndex :: Integer -> TContext -> TContext
+incrementIndex n = applyIndexContext (updateIndex n)
+
+pointFromContext :: TContext -> Point
+pointFromContext TContext {fileName = name, source = s, tIndex = point} = point

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -1,7 +1,9 @@
 module Utils (
   isNumeric,
   isKeyword,
-  isPuntuation
+  isPuntuation,
+  removeLine,
+  nextWord
 ) where
 
 keywords = ["where", "let", "in", "import", "\\", "data", "_", "class", "type", "instance", "module"]
@@ -26,3 +28,16 @@ isKeyword = flip elem keywords
 
 isPuntuation :: String -> Bool
 isPuntuation = flip elem puntuations
+
+removeLine :: String -> String
+removeLine "" = ""
+removeLine ('\n':xs) = xs
+removeLine (_:xs) = removeLine xs
+
+nextWord :: String -> String
+nextWord ""                                                      = ""
+nextWord ('-':'-':xs)                                            = ""
+nextWord (' ':xs)                                                = ""
+nextWord ('\n':xs)                                               = "" 
+nextWord (x:xs) | isPuntuation (x:"")                            = ""
+                | otherwise                                      = x : nextWord xs

--- a/test/TestLexer.hs
+++ b/test/TestLexer.hs
@@ -13,6 +13,9 @@ tokenize_test description source expectedTokens =
 right_tokenize_test :: String -> String -> [Token] -> Test
 right_tokenize_test description source expectedTokens = tokenize_test description source (Right expectedTokens)
 
+left_tokenize_test :: String -> String -> Error -> Test
+left_tokenize_test description source expectedError = tokenize_test description source (Left expectedError)
+
 tests :: TestSuite
 tests = TestSuite "LEXER" [
   right_tokenize_test "Empty program" "" [],
@@ -89,5 +92,6 @@ tests = TestSuite "LEXER" [
     Token (TPosition (Point 1 9 40) (Point 1 10 41)) (PToken Colon),
     Token (TPosition (Point 1 11 41) (Point 1 19 49)) (IDToken "tokenize"),
     Token (TPosition (Point 1 20 49) (Point 1 22 51)) (IDToken "xs")
-    ]
+    ],
+    left_tokenize_test "Try tokenize a program with a lexicographical error" "tokenize (x:xs) = case (tokenize x) \n word -> word : tokenize xs \n __ -> _" (Error LexicographicalError "__ is not a valid word" (Point 2 1 51) "__ -> _") 
   ]

--- a/test/TestLexer.hs
+++ b/test/TestLexer.hs
@@ -4,44 +4,48 @@ module TestLexer(tests) where
 import Test(TestSuite(..), Test(..))
 
 import Lexer
+import Error
 
-tokenize_test :: String -> String -> [Token] -> Test
+tokenize_test :: String -> String -> Either Error [Token] -> Test
 tokenize_test description source expectedTokens =
   TestCase description (tokenizeProgram "Test" source) expectedTokens
 
+right_tokenize_test :: String -> String -> [Token] -> Test
+right_tokenize_test description source expectedTokens = tokenize_test description source (Right expectedTokens)
+
 tests :: TestSuite
 tests = TestSuite "LEXER" [
-  tokenize_test "Empty program" "" [],
+  right_tokenize_test "Empty program" "" [],
   -- Numbers
-  tokenize_test "Number 42 to a NToken" "42" [Token (TPosition (Point 0 0 0) (Point 0 2 2)) (NToken 42) ],
-  tokenize_test "Number 01 to a NToken" "01" [Token (TPosition (Point 0 0 0) (Point 0 2 2)) (NToken 01) ],
-  tokenize_test "Number 10 to a NToken" "10" [Token (TPosition (Point 0 0 0) (Point 0 2 2)) (NToken 10) ],
+  right_tokenize_test "Number 42 to a NToken" "42" [Token (TPosition (Point 0 0 0) (Point 0 2 2)) (NToken 42) ],
+  right_tokenize_test "Number 01 to a NToken" "01" [Token (TPosition (Point 0 0 0) (Point 0 2 2)) (NToken 01) ],
+  right_tokenize_test "Number 10 to a NToken" "10" [Token (TPosition (Point 0 0 0) (Point 0 2 2)) (NToken 10) ],
   -- Identifiers
-  tokenize_test "ID if to IDToken" "if" [Token (TPosition (Point 0 0 0) (Point 0 2 2)) (IDToken "if") ],
-  tokenize_test "ID then to IDToken" "then"  [Token (TPosition (Point 0 0 0) (Point 0 4 4)) (IDToken "then") ],
-  tokenize_test "ID function to IDToken" "function" [Token (TPosition (Point 0 0 0) (Point 0 8 8)) (IDToken "function") ],
+  right_tokenize_test "ID if to IDToken" "if" [Token (TPosition (Point 0 0 0) (Point 0 2 2)) (IDToken "if") ],
+  right_tokenize_test "ID then to IDToken" "then"  [Token (TPosition (Point 0 0 0) (Point 0 4 4)) (IDToken "then") ],
+  right_tokenize_test "ID function to IDToken" "function" [Token (TPosition (Point 0 0 0) (Point 0 8 8)) (IDToken "function") ],
   -- Keywords
-  tokenize_test "Keyword Where to KToken" "where" [Token (TPosition (Point 0 0 0) (Point 0 5 5)) (KToken Where) ],
-  tokenize_test "Keyword Module to KToken" "module" [Token (TPosition (Point 0 0 0) (Point 0 6 6)) (KToken Module) ],
-  tokenize_test "Keyword Let to KToken" "let" [Token (TPosition (Point 0 0 0) (Point 0 3 3)) (KToken Let) ],
-  tokenize_test "Keyword In to KToken" "in" [Token (TPosition (Point 0 0 0) (Point 0 2 2)) (KToken In) ],
-  tokenize_test "Keyword Import to KToken" "import" [Token (TPosition (Point 0 0 0) (Point 0 6 6)) (KToken Import) ],
-  tokenize_test "Keyword Backslash to KToken" "\\" [Token (TPosition (Point 0 0 0) (Point 0 1 1)) (KToken Backslash) ],
-  tokenize_test "Keyword Data to KToken" "data" [Token (TPosition (Point 0 0 0) (Point 0 4 4)) (KToken Data) ],
-  tokenize_test "Keyword Underscore to KToken" "_" [Token (TPosition (Point 0 0 0) (Point 0 1 1)) (KToken Underscore) ],
-  tokenize_test "Keyword Class to KToken" "class" [Token (TPosition (Point 0 0 0) (Point 0 5 5)) (KToken Class) ],
-  tokenize_test "Keyword Type to KToken" "type" [Token (TPosition (Point 0 0 0) (Point 0 4 4)) (KToken Type) ],
-  tokenize_test "Keyword Instance to KToken" "instance" [Token (TPosition (Point 0 0 0) (Point 0 8 8)) (KToken Instance) ],
+  right_tokenize_test "Keyword Where to KToken" "where" [Token (TPosition (Point 0 0 0) (Point 0 5 5)) (KToken Where) ],
+  right_tokenize_test "Keyword Module to KToken" "module" [Token (TPosition (Point 0 0 0) (Point 0 6 6)) (KToken Module) ],
+  right_tokenize_test "Keyword Let to KToken" "let" [Token (TPosition (Point 0 0 0) (Point 0 3 3)) (KToken Let) ],
+  right_tokenize_test "Keyword In to KToken" "in" [Token (TPosition (Point 0 0 0) (Point 0 2 2)) (KToken In) ],
+  right_tokenize_test "Keyword Import to KToken" "import" [Token (TPosition (Point 0 0 0) (Point 0 6 6)) (KToken Import) ],
+  right_tokenize_test "Keyword Backslash to KToken" "\\" [Token (TPosition (Point 0 0 0) (Point 0 1 1)) (KToken Backslash) ],
+  right_tokenize_test "Keyword Data to KToken" "data" [Token (TPosition (Point 0 0 0) (Point 0 4 4)) (KToken Data) ],
+  right_tokenize_test "Keyword Underscore to KToken" "_" [Token (TPosition (Point 0 0 0) (Point 0 1 1)) (KToken Underscore) ],
+  right_tokenize_test "Keyword Class to KToken" "class" [Token (TPosition (Point 0 0 0) (Point 0 5 5)) (KToken Class) ],
+  right_tokenize_test "Keyword Type to KToken" "type" [Token (TPosition (Point 0 0 0) (Point 0 4 4)) (KToken Type) ],
+  right_tokenize_test "Keyword Instance to KToken" "instance" [Token (TPosition (Point 0 0 0) (Point 0 8 8)) (KToken Instance) ],
   -- Puntuation
-  tokenize_test "Puntuation LeftParen to a PToken" "(" [Token (TPosition (Point 0 0 0) (Point 0 1 1)) (PToken LeftParen) ],
-  tokenize_test "Puntuation RightParen to a PToken" ")" [Token (TPosition (Point 0 0 0) (Point 0 1 1)) (PToken RightParen) ],
-  tokenize_test "Puntuation LeftBrace to a PToken" "{" [Token (TPosition (Point 0 0 0) (Point 0 1 1)) (PToken LeftBrace) ],
-  tokenize_test "Puntuation RightBrace to a PToken" "}" [Token (TPosition (Point 0 0 0) (Point 0 1 1)) (PToken RightBrace) ],
-  tokenize_test "Puntuation SemiColon to a PToken" ";" [Token (TPosition (Point 0 0 0) (Point 0 1 1)) (PToken SemiColon) ],
-  tokenize_test "Puntuation Colon to a PToken" ":" [Token (TPosition (Point 0 0 0) (Point 0 1 1)) (PToken Colon) ],
-  tokenize_test "Puntuation Equal to a PToken" "=" [Token (TPosition (Point 0 0 0) (Point 0 1 1)) (PToken Equal) ],
-  tokenize_test "Puntuation Arrow to a PToken" "=>" [Token (TPosition (Point 0 0 0) (Point 0 2 2)) (PToken Arrow) ],
-  tokenize_test "Chaining identifiers and some puntuations" "a=>b:c;d=e" [
+  right_tokenize_test "Puntuation LeftParen to a PToken" "(" [Token (TPosition (Point 0 0 0) (Point 0 1 1)) (PToken LeftParen) ],
+  right_tokenize_test "Puntuation RightParen to a PToken" ")" [Token (TPosition (Point 0 0 0) (Point 0 1 1)) (PToken RightParen) ],
+  right_tokenize_test "Puntuation LeftBrace to a PToken" "{" [Token (TPosition (Point 0 0 0) (Point 0 1 1)) (PToken LeftBrace) ],
+  right_tokenize_test "Puntuation RightBrace to a PToken" "}" [Token (TPosition (Point 0 0 0) (Point 0 1 1)) (PToken RightBrace) ],
+  right_tokenize_test "Puntuation SemiColon to a PToken" ";" [Token (TPosition (Point 0 0 0) (Point 0 1 1)) (PToken SemiColon) ],
+  right_tokenize_test "Puntuation Colon to a PToken" ":" [Token (TPosition (Point 0 0 0) (Point 0 1 1)) (PToken Colon) ],
+  right_tokenize_test "Puntuation Equal to a PToken" "=" [Token (TPosition (Point 0 0 0) (Point 0 1 1)) (PToken Equal) ],
+  right_tokenize_test "Puntuation Arrow to a PToken" "=>" [Token (TPosition (Point 0 0 0) (Point 0 2 2)) (PToken Arrow) ],
+  right_tokenize_test "Chaining identifiers and some puntuations" "a=>b:c;d=e" [
     Token (TPosition (Point 0 0 0) (Point 0 1 1)) (IDToken "a"),
     Token (TPosition (Point 0 1 1) (Point 0 3 3)) (PToken Arrow),
     Token (TPosition (Point 0 3 3) (Point 0 4 4)) (IDToken "b"),
@@ -53,19 +57,19 @@ tests = TestSuite "LEXER" [
     Token (TPosition (Point 0 9 9) (Point 0 10 10)) (IDToken "e")
   ],
   -- Ignore comments
-  tokenize_test "Ignoring single comment" "--this is a comment" [],
-  tokenize_test "Ignoring comment between lines" "a b\n--c d e f\ng"  [
+  right_tokenize_test "Ignoring single comment" "--this is a comment" [],
+  right_tokenize_test "Ignoring comment between lines" "a b\n--c d e f\ng"  [
     Token (TPosition (Point 0 0 0) (Point 0 1 1)) (IDToken "a"),
     Token (TPosition (Point 0 2 1) (Point 0 3 2)) (IDToken "b"),
     Token (TPosition (Point 2 0 2) (Point 2 1 3)) (IDToken "g")
   ],
   tokenize_test "Ignoring complex comments" "module Lexer where --where\n--this is a comment\nid a = a --identity" (tokenizeProgram "Test" "module Lexer where\n\nid a = a"),
   -- Complex programs
-  tokenize_test "Tokenize a program with two tokens" "42 if" [
+  right_tokenize_test "Tokenize a program with two tokens" "42 if" [
     Token (TPosition (Point 0 0 0) (Point 0 2 2)) (NToken 42),
     Token (TPosition (Point 0 3 2) (Point 0 5 4)) (IDToken "if")
   ],
-  tokenize_test "Tokenize a program with puntuation and indentifiers" " tokenize (x:xs) = let word = (tokenize x) \n in word : tokenize xs" [
+  right_tokenize_test "Tokenize a program with puntuation and indentifiers" " tokenize (x:xs) = let word = (tokenize x) \n in word : tokenize xs" [
     Token (TPosition (Point 0 1 0) (Point 0 9 8)) (IDToken "tokenize"),
     Token (TPosition (Point 0 10 8) (Point 0 11 9)) (PToken LeftParen),
     Token (TPosition (Point 0 11 9) (Point 0 12 10)) (IDToken "x"),


### PR DESCRIPTION
### Define general error

As mentions the title, this pr defines a new data structure `Error` that going to be utilised by all the part of the language. Also, as part of this pr:
 - The complex data structures were moved to another files 
 - Change the Lexer implementation to return `Either Error [Token]`
 - All the tests were updated to handle Either results
 - A test case to handle our lexicographical wrong case ("__")